### PR TITLE
Use Nonebot2's default loguru logger to forward to reggol instead of directly replacing it with reggol logger

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 temp
 dist
 lib
+build

--- a/packages/nonebot/python/nonebot/__init__.py
+++ b/packages/nonebot/python/nonebot/__init__.py
@@ -13,7 +13,8 @@ from internal import on_command as on_command
 from internal import on_shell_command as on_shell_command
 
 from internal import get_driver as get_driver
-from internal import logger as logger
+
+from .log import logger as logger
 
 import internal
 from .adapters.onebot.v11 import Bot

--- a/packages/nonebot/python/nonebot/__init__.py
+++ b/packages/nonebot/python/nonebot/__init__.py
@@ -1,35 +1,40 @@
-from internal import on_message as on_message
-from internal import on_metaevent as on_metaevent
-from internal import on_notice as on_notice
-from internal import on_request as on_request
-
-from internal import on_regex as on_regex
-from internal import on_keyword as on_keyword
-from internal import on_endswith as on_endswith
-from internal import on_fullmatch as on_fullmatch
-from internal import on_startswith as on_startswith
-
-from internal import on_command as on_command
-from internal import on_shell_command as on_shell_command
+import internal
 
 from internal import get_driver as get_driver
 
-from .log import logger as logger
+from internal import on_message as on_message
+from internal import on_command as on_command
+from internal import on_shell_command as on_shell_command
 
-import internal
+from internal import on_keyword as on_keyword
+from internal import on_regex as on_regex
+from internal import on_fullmatch as on_fullmatch
+
+from internal import on_notice as on_notice
+from internal import on_request as on_request
+from internal import on_metaevent as on_metaevent
+
+from internal import on_startswith as on_startswith
+from internal import on_endswith as on_endswith
+
 from .adapters.onebot.v11 import Bot
+
+from .log import logger as logger
 
 
 def require(*args, **kwargs):
-  pass
+    pass
 
 
 def get_bot(*args, **kwargs):
-  return Bot(internal.ctx.bots[0], internal.unwrap)
+    return Bot(internal.ctx.bots[0], internal.unwrap)
 
 
 def get_bots(*args, **kwargs):
-  dict = {}
-  for bot in internal.ctx.bots:
-    dict[bot.selfId] = Bot(bot, internal.unwrap)
-  return dict
+    bots = {}
+    for bot in internal.ctx.bots:
+        bots[bot.selfId] = Bot(bot, internal.unwrap)
+    return bots
+
+
+logger.success("nonebot loaded")

--- a/packages/nonebot/python/nonebot/exception.py
+++ b/packages/nonebot/python/nonebot/exception.py
@@ -25,68 +25,68 @@ NoneBotException
 
 
 class NoneBotException(Exception):
-  pass
+    pass
 
 
 class ParserExit(NoneBotException):
-	pass
+    pass
 
 
 class ProcessException(NoneBotException):
-  pass
+    pass
 
 
 class IgnoredException(ProcessException):
-  pass
+    pass
 
 
 class SkippedException(ProcessException):
-  pass
+    pass
 
 
 class TypeMisMatch(SkippedException):
-  pass
+    pass
 
 
 class MockApiException(ProcessException):
-  pass
+    pass
 
 
 class StopPropagation(ProcessException):
-  pass
+    pass
 
 
 class MatcherException(NoneBotException):
-  pass
+    pass
 
 
 class PausedException(MatcherException):
-  pass
+    pass
 
 
 class RejectedException(MatcherException):
-  pass
+    pass
 
 
 class FinishedException(MatcherException):
-  pass
+    pass
 
 
 class AdapterException(NoneBotException):
-  pass
+    pass
 
 
 class NoLogException(AdapterException):
-  pass
+    pass
 
 
 class ApiNotAvailable(AdapterException):
-  pass
+    pass
 
 
 class NetworkError(AdapterException):
-  pass
+    pass
 
 
 class ActionFailed(AdapterException):
-  pass
+    pass

--- a/packages/nonebot/python/nonebot/internal/__init__.pyi
+++ b/packages/nonebot/python/nonebot/internal/__init__.pyi
@@ -1,0 +1,22 @@
+from typing import Protocol
+
+class ReggolLogger(Protocol):
+    def success(self, obj, *args):
+        pass
+
+    def error(self, obj, *args):
+        pass
+
+    def info(self, obj, *args):
+        pass
+
+    def warn(self, obj, *args):
+        pass
+
+    def debug(self, obj, *args):
+        pass
+
+class NonebotJSLogger(ReggolLogger, Protocol):
+    warning = ReggolLogger.warn
+
+logger: NonebotJSLogger

--- a/packages/nonebot/python/nonebot/internal/__init__.pyi
+++ b/packages/nonebot/python/nonebot/internal/__init__.pyi
@@ -1,35 +1,57 @@
-from typing import Protocol, Callable, Any, Dict, Sequence
+from typing import Any
 
-class Context(Protocol):
-    runtime: "Context"
-    scope: "Context"
-    bots: Sequence
-    nonebot: "Context"
-    root: "Context"
+from .jsobject import JSProxyObject, JSProxyCallable, JSObject
+from .types import *
 
-class Service(Protocol):
-    ctx: Context
 
-class ReggolLogger(Protocol):
-    def success(self, obj, *args):
-        pass
+def on_message(*args, **kwargs):  # real signature unknown
+    pass
 
-    def error(self, obj, *args):
-        pass
 
-    def info(self, obj, *args):
-        pass
+def on_metaevent(*args, **kwargs):  # real signature unknown
+    pass
 
-    def warn(self, obj, *args):
-        pass
 
-    def debug(self, obj, *args):
-        pass
+def on_notice(*args, **kwargs):  # real signature unknown
+    pass
 
-class NonebotJSLogger(ReggolLogger, Protocol):
-    warning = ReggolLogger.warn
 
-logger: NonebotJSLogger
-unwrap: Callable[[Any], Any]
-config: Dict | Any
-caller: "Context"
+def on_request(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_regex(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_keyword(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_endswith(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_fullmatch(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_startswith(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_command(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def on_shell_command(*args, **kwargs):  # real signature unknown
+    pass
+
+
+def get_driver(*args, **kwargs):  # real signature unknown
+    pass
+
+
+logger: JSObject[NonebotJSLogger]
+unwrap: JSProxyCallable[[Any], Any]
+ctx: JSObject[Context]

--- a/packages/nonebot/python/nonebot/internal/__init__.pyi
+++ b/packages/nonebot/python/nonebot/internal/__init__.pyi
@@ -1,4 +1,14 @@
-from typing import Protocol
+from typing import Protocol, Callable, Any, Dict, Sequence
+
+class Context(Protocol):
+    runtime: "Context"
+    scope: "Context"
+    bots: Sequence
+    nonebot: "Context"
+    root: "Context"
+
+class Service(Protocol):
+    ctx: Context
 
 class ReggolLogger(Protocol):
     def success(self, obj, *args):
@@ -20,3 +30,6 @@ class NonebotJSLogger(ReggolLogger, Protocol):
     warning = ReggolLogger.warn
 
 logger: NonebotJSLogger
+unwrap: Callable[[Any], Any]
+config: Dict | Any
+caller: "Context"

--- a/packages/nonebot/python/nonebot/internal/config.pyi
+++ b/packages/nonebot/python/nonebot/internal/config.pyi
@@ -1,5 +1,6 @@
 from .jsobject import PythonizeObject
+from typing import Any
 
 
-def to_py() -> dict:
+def to_py() -> dict[str, Any]:
     pass

--- a/packages/nonebot/python/nonebot/internal/config.pyi
+++ b/packages/nonebot/python/nonebot/internal/config.pyi
@@ -1,0 +1,5 @@
+from .jsobject import PythonizeObject
+
+
+def to_py() -> dict:
+    pass

--- a/packages/nonebot/python/nonebot/internal/ctx.pyi
+++ b/packages/nonebot/python/nonebot/internal/ctx.pyi
@@ -1,0 +1,6 @@
+from . import Context
+from .jsobject import PythonizeObject
+
+
+def to_py() -> PythonizeObject[Context]:
+    pass

--- a/packages/nonebot/python/nonebot/internal/jsobject.pyi
+++ b/packages/nonebot/python/nonebot/internal/jsobject.pyi
@@ -1,0 +1,26 @@
+from typing import Generic, TypeVar, Callable, Any
+
+T = TypeVar("T")
+V = TypeVar("V")
+K = TypeVar("K")
+S = TypeVar("S")
+
+
+class PythonizeObject(Generic[T]):
+    def __getattr__(self, item) -> JSProxyObject | Any:
+        pass
+
+
+class JSProxyObject(Generic[T]):
+    def to_py(self) -> PythonizeObject[T] | T:  # real signature unknown
+        ...
+
+    def __getattr__(self, item) -> JSProxyObject[T]:  # real signature unknown
+        ...
+
+
+class JSProxyCallable(Callable, JSProxyObject):
+    ...
+
+
+JSObject = JSProxyObject[S] | S

--- a/packages/nonebot/python/nonebot/internal/rule.py
+++ b/packages/nonebot/python/nonebot/internal/rule.py
@@ -1,4 +1,4 @@
-from nonebot.internal.params import Dependent
+from .params import Dependent
 
 
 class Rule:

--- a/packages/nonebot/python/nonebot/internal/types.pyi
+++ b/packages/nonebot/python/nonebot/internal/types.pyi
@@ -1,41 +1,54 @@
-from typing import Sequence, Protocol
+from typing import Sequence, Protocol, Awaitable, Callable, Any
 
-from .jsobject import JSProxyObject, JSObject
+from .jsobject import JSProxyObject, JSObject, JSProxyCallable
+
+import config
 
 
 class Config(dict):
-    pass
+  pass
 
 
 class Context(Protocol):
-    runtime: JSObject["Context"]
-    scope: JSObject["Context"]
-    bots: JSObject[Sequence]
-    nonebot: JSObject["Service"]
-    root: JSObject["Context"]
-    config: JSProxyObject[Config]
+  runtime: JSObject["Context"]
+  scope: JSObject["Context"]
+  bots: JSObject[Sequence]
+  nonebot: JSObject["Service"]
+  root: JSObject["Context"]
+  config: JSProxyObject[Config]
 
 
 class Service(Protocol):
-    ctx: JSObject[Context]
+  ctx: JSObject[Context]
+  config: config
+
+
+class NonebotService(Service, Protocol):
+  loadDep: JSProxyCallable[Awaitable[Callable[[str, dict], None]]]
+  install: JSProxyCallable[Awaitable[Callable[[str], None]]]
+  installed: JSProxyObject[dict]
+  path: JSProxyObject[dict]
+  internal: "internal"
+  python: Any
+
 
 
 class ReggolLogger(Protocol):
-    def success(self, obj, *args):
-        pass
+  def success(self, obj, *args):
+    pass
 
-    def error(self, obj, *args):
-        pass
+  def error(self, obj, *args):
+    pass
 
-    def info(self, obj, *args):
-        pass
+  def info(self, obj, *args):
+    pass
 
-    def warn(self, obj, *args):
-        pass
+  def warn(self, obj, *args):
+    pass
 
-    def debug(self, obj, *args):
-        pass
+  def debug(self, obj, *args):
+    pass
 
 
 class NonebotJSLogger(ReggolLogger, Protocol):
-    warning = ReggolLogger.warn
+  warning = ReggolLogger.warn

--- a/packages/nonebot/python/nonebot/internal/types.pyi
+++ b/packages/nonebot/python/nonebot/internal/types.pyi
@@ -1,0 +1,41 @@
+from typing import Sequence, Protocol
+
+from .jsobject import JSProxyObject, JSObject
+
+
+class Config(dict):
+    pass
+
+
+class Context(Protocol):
+    runtime: JSObject["Context"]
+    scope: JSObject["Context"]
+    bots: JSObject[Sequence]
+    nonebot: JSObject["Service"]
+    root: JSObject["Context"]
+    config: JSProxyObject[Config]
+
+
+class Service(Protocol):
+    ctx: JSObject[Context]
+
+
+class ReggolLogger(Protocol):
+    def success(self, obj, *args):
+        pass
+
+    def error(self, obj, *args):
+        pass
+
+    def info(self, obj, *args):
+        pass
+
+    def warn(self, obj, *args):
+        pass
+
+    def debug(self, obj, *args):
+        pass
+
+
+class NonebotJSLogger(ReggolLogger, Protocol):
+    warning = ReggolLogger.warn

--- a/packages/nonebot/python/nonebot/log.py
+++ b/packages/nonebot/python/nonebot/log.py
@@ -12,7 +12,7 @@ async def handle(message: "loguru.Message"):
 logger.remove()
 logger.add(
 	handle,
-	format="\b<green>:</><cyan>{name}</><green>:</><cyan>{function}</> {message}",
+	format="<cyan>{name}</><green>:</><cyan>{function}</> {message}",
 	colorize=True,
 	diagnose=True
 )

--- a/packages/nonebot/python/nonebot/log.py
+++ b/packages/nonebot/python/nonebot/log.py
@@ -1,25 +1,18 @@
-from internal import logger as internal_logger
+import loguru
 from loguru import logger
 
-import logging
+from internal import logger as internal_logger
+
+
+async def handle(message: "loguru.Message"):
+	func = getattr(internal_logger, message.record['level'].name.lower(), internal_logger.info)
+	func(message)
+
 
 logger.remove()
-logger.add(internal_logger.info, format="<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - {message}")
-
-class LoguruHandler(logging.Handler):  # pragma: no cover
-	"""logging 与 loguru 之间的桥梁，将 logging 的日志转发到 loguru。"""
-
-	def emit(self, record: logging.LogRecord):
-		try:
-			level = logger.level(record.levelname).name
-		except ValueError:
-			level = record.levelno
-
-		frame, depth = logging.currentframe(), 2
-		while frame and frame.f_code.co_filename == logging.__file__:
-			frame = frame.f_back
-			depth += 1
-
-		logger.opt(depth=depth, exception=record.exc_info).log(
-			level, record.getMessage()
-		)
+logger.add(
+	handle,
+	format="\b<green>:</><cyan>{name}</><green>:</><cyan>{function}</> {message}",
+	colorize=True,
+	diagnose=True
+)

--- a/packages/nonebot/python/nonebot/log.py
+++ b/packages/nonebot/python/nonebot/log.py
@@ -1,6 +1,10 @@
-from internal import logger as logger
+from internal import logger as internal_logger
+from loguru import logger
 
 import logging
+
+logger.remove()
+logger.add(internal_logger.info, format="<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - {message}")
 
 class LoguruHandler(logging.Handler):  # pragma: no cover
 	"""logging 与 loguru 之间的桥梁，将 logging 的日志转发到 loguru。"""

--- a/packages/nonebot/python/nonebot/log.py
+++ b/packages/nonebot/python/nonebot/log.py
@@ -6,7 +6,7 @@ from internal import logger as internal_logger
 
 async def handle(message: "loguru.Message"):
 	func = getattr(internal_logger, message.record['level'].name.lower(), internal_logger.info)
-	func(message)
+	func(message.removesuffix('\n'))
 
 
 logger.remove()

--- a/packages/nonebot/python/nonebot/log.py
+++ b/packages/nonebot/python/nonebot/log.py
@@ -2,17 +2,19 @@ import loguru
 from loguru import logger
 
 from internal import logger as internal_logger
+from internal import ctx
 
 
 async def handle(message: "loguru.Message"):
-	func = getattr(internal_logger, message.record['level'].name.lower(), internal_logger.info)
-	func(message.removesuffix('\n'))
+    func = getattr(internal_logger, message.record['level'].name.lower(), internal_logger.info)
+    func(message.removesuffix('\n'))
 
 
 logger.remove()
 logger.add(
-	handle,
-	format="<cyan>{name}</><green>:</><cyan>{function}</> {message}",
-	colorize=True,
-	diagnose=True
+    handle,
+    format="<cyan>{name}</><green>:</><cyan>{function}</> {message}",
+    colorize=ctx.config.to_py().get('colorize', True),
+    diagnose=ctx.config.to_py().get('diagnose', False),
+    backtrace=ctx.config.to_py().get('backtrace', False)
 )

--- a/packages/nonebot/python/nonebot/log.py
+++ b/packages/nonebot/python/nonebot/log.py
@@ -12,7 +12,7 @@ async def handle(message: "loguru.Message"):
 logger.remove()
 logger.add(
 	handle,
-	format="<cyan>{name}</><green>:</><cyan>{function}</> {message}",
+	format="\b<green>:</><cyan>{name}</><green>:</><cyan>{function}</> {message}",
 	colorize=True,
 	diagnose=True
 )

--- a/packages/nonebot/src/index.ts
+++ b/packages/nonebot/src/index.ts
@@ -137,7 +137,7 @@ class NoneBot extends Service {
 
 namespace NoneBot {
   export interface Config {
-    siteFolder?: string,
+    siteFolder?: string
     backtrace: boolean
   }
 
@@ -146,14 +146,14 @@ namespace NoneBot {
       .description('site-packages 目录。')
       .default('data/nonebot/site-packages'),
     backtrace: Schema.boolean()
-        .description('向前追踪错误')
-        .default(false),
+      .description('向前追踪错误')
+      .default(false),
     colorize: Schema.boolean()
-        .description('输出彩色日志')
-        .default(true),
+      .description('输出彩色日志')
+      .default(true),
     diagnose: Schema.boolean()
-        .description('日志错误诊断')
-        .default(false),
+      .description('日志错误诊断')
+      .default(false),
   })
 }
 

--- a/packages/nonebot/src/index.ts
+++ b/packages/nonebot/src/index.ts
@@ -110,7 +110,11 @@ class NoneBot extends Service {
     return this.importTask = this.importTask.then(async () => {
       this.internal.caller = caller
       this.internal.config = config
-      await this.python.runPythonAsync(`import ${name}`)
+      await this.python.runPythonAsync(`
+      from nonebot import logger
+      from importlib import __import__
+      logger.catch(lambda: __import__('''${name}'''))()
+      `)
       this.internal.caller = null
       this.internal.config = null
     })
@@ -133,13 +137,23 @@ class NoneBot extends Service {
 
 namespace NoneBot {
   export interface Config {
-    siteFolder?: string
+    siteFolder?: string,
+    backtrace: boolean
   }
 
   export const Config: Schema<Config> = Schema.object({
     siteFolder: Schema.string()
       .description('site-packages 目录。')
       .default('data/nonebot/site-packages'),
+    backtrace: Schema.boolean()
+        .description('向前追踪错误')
+        .default(false),
+    colorize: Schema.boolean()
+        .description('输出彩色日志')
+        .default(true),
+    diagnose: Schema.boolean()
+        .description('日志错误诊断')
+        .default(false),
   })
 }
 

--- a/packages/nonebot/src/internal/index.ts
+++ b/packages/nonebot/src/internal/index.ts
@@ -15,7 +15,7 @@ export class Internal {
     },
   })
 
-  constructor(protected ctx: Context) {ctx.bots}
+  constructor(protected ctx: Context) {}
 
   h(type: string, attrs?: any, children?: any) {
     if (type === 'music') type = 'onebot:music'

--- a/packages/nonebot/src/internal/index.ts
+++ b/packages/nonebot/src/internal/index.ts
@@ -15,7 +15,7 @@ export class Internal {
     },
   })
 
-  constructor(protected ctx: Context) {}
+  constructor(protected ctx: Context) {ctx.bots}
 
   h(type: string, attrs?: any, children?: any) {
     if (type === 'music') type = 'onebot:music'

--- a/packages/nonebot/src/internal/matcher.ts
+++ b/packages/nonebot/src/internal/matcher.ts
@@ -95,7 +95,13 @@ export class BaseMatcher {
     const params: Parameter[] = this.getParams(fn)
     let wrapper = this.ctx.nonebot.python.runPython(`
       from nonebot import logger
-      logger.opt(depth=-2).catch
+      
+      def wrap_error_catch(func):
+        wrapped = logger.catch(func)
+        def error_catch_wrapper(*args, **kwargs):
+          wrapped(*args, **kwargs)
+        return error_catch_wrapper
+      wrap_error_catch
     `)
     const callback = wrapper(fn).toJs()
     return async () => {

--- a/packages/nonebot/src/internal/matcher.ts
+++ b/packages/nonebot/src/internal/matcher.ts
@@ -93,7 +93,11 @@ export class BaseMatcher {
 
   protected parseFn(fn: PyProxy) {
     const params: Parameter[] = this.getParams(fn)
-    const callback = fn.toJs()
+    let wrapper = this.ctx.nonebot.python.runPython(`
+      from nonebot import logger
+      logger.opt(depth=-2).catch
+    `)
+    const callback = wrapper(fn).toJs()
     return async () => {
       const args = await Promise.all(params.map((param) => {
         const key = fallbackMap[param.name] || param.name

--- a/packages/nonebot/src/internal/matcher.ts
+++ b/packages/nonebot/src/internal/matcher.ts
@@ -93,9 +93,9 @@ export class BaseMatcher {
 
   protected parseFn(fn: PyProxy) {
     const params: Parameter[] = this.getParams(fn)
-    let wrapper = this.ctx.nonebot.python.runPython(`
+    const wrapper = this.ctx.nonebot.python.runPython(`
       from nonebot import logger
-      
+
       def wrap_error_catch(func):
         wrapped = logger.catch(func)
         def error_catch_wrapper(*args, **kwargs):
@@ -169,7 +169,7 @@ export class BaseMatcher {
       for (const callback of this.callbacks) {
         await callback()
       }
-    } catch (e) {
+    } catch (e: Error | any) {
       if (!NoneBotException.check(e)) logger.warn(e)
     }
   }

--- a/packages/nonebot/src/internal/matcher.ts
+++ b/packages/nonebot/src/internal/matcher.ts
@@ -33,7 +33,7 @@ export class BaseMatcher {
   protected callbacks: (() => Promise<void>)[] = []
   protected message: string
   protected capture: RegExpExecArray
-  protected errorCatch: PyProxy
+  protected errorCatch: ((func: PyProxy) => PyProxy) | any
 
   protected getters = {
     Bot: () => {
@@ -72,7 +72,7 @@ export class BaseMatcher {
           wrapped(*args, **kwargs)
         return error_catch_wrapper
       wrap_error_catch
-    `)
+    `).toJs()
 
     if (kwargs.handlers) {
       for (const handler of unwrap(kwargs.handlers)) {

--- a/plugins/test/.npmignore
+++ b/plugins/test/.npmignore
@@ -1,0 +1,3 @@
+__pycache__
+.DS_Store
+tsconfig.tsbuildinfo

--- a/plugins/test/nb-test/__init__.py
+++ b/plugins/test/nb-test/__init__.py
@@ -1,0 +1,39 @@
+from nonebot import logger, on_command
+
+
+class SomethingWentWrongError(Exception):
+	pass
+
+
+logger.debug('test [debug]')
+logger.warning('test [warning]')
+logger.info('test [info]')
+logger.error('test [error]')
+
+logger.info('message with {}', 'format string')
+logger.info('message with {kwargs1}', kwargs1='keyword argument')
+logger.info('message with {dict1}', dict1={
+	"with": 'dict',
+	"foo": 'bar'
+})
+
+logger.opt(colors=True).info('message with <yellow>colored</> <cyan>text</cyan>')
+logger.opt(colors=True).info('message with <fg #AFFFAF>hex</> <bg>color</>')
+logger.opt(colors=True).info('message with <green>also</> <bg cyan>color</>')
+
+
+@logger.catch
+def func_that_raise_error():
+	raise SomethingWentWrongError("Hey, what happened?")
+
+
+exc_matcher = on_command('exc')
+
+
+@exc_matcher.handle()
+def exc():
+	exc_matcher.send(f'Is going to raise a {SomethingWentWrongError.__name__}')
+	raise SomethingWentWrongError(
+		"There is something wrong with this command, "
+		"absolutely not manually raised"
+	)

--- a/plugins/test/nbp.json
+++ b/plugins/test/nbp.json
@@ -1,0 +1,4 @@
+{
+  "name": "nonebot-plugin-vf",
+  "version": "1.3.0"
+}

--- a/plugins/test/nbp.json
+++ b/plugins/test/nbp.json
@@ -1,4 +1,4 @@
 {
-  "name": "nonebot-plugin-vf",
-  "version": "1.3.0"
+  "name": "nonebot-plugin-nonebotjs-tester",
+  "version": "0.0.0"
 }

--- a/plugins/test/package.json
+++ b/plugins/test/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@nonebot/koishi-plugin-nonebotjs-tester",
-  "private": true,
+  "name": "koishi-plugin-nonebotjs-tester",
   "description": "plugin test nonebotjs",
   "version": "1.0.0",
   "main": "lib/index.js",
@@ -41,7 +40,7 @@
     "koishi-plugin-nonebot": "^1.2.2"
   },
   "devDependencies": {
-    "@types/node": "^18.16.14",
+    "@types/node": "^20.2.5",
     "atsc": "^1.2.2",
     "koishi": "^4.13.0",
     "koishi-plugin-nonebot": "^1.2.2",

--- a/plugins/test/package.json
+++ b/plugins/test/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@nonebot/koishi-plugin-nonebotjs-tester",
+  "private": true,
+  "description": "plugin test nonebotjs",
+  "version": "1.0.0",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "dist",
+    "nb-test"
+  ],
+  "author": "NoneBot.js <nonebot@proton.me>",
+  "contributors": [
+    "NoneBot.js <nonebot@proton.me>",
+    "Cyan <lc_shizuku@outlook.com>"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Chinese-Cyq20100313/koishi-plugin-nonebot.git"
+  },
+  "homepage": "https://nonebot.koishi.chat",
+  "koishi": {
+    "service": {
+      "required": [
+        "nonebot"
+      ]
+    }
+  },
+  "keywords": [
+    "bot",
+    "chatbot",
+    "koishi",
+    "plugin",
+    "nonebot",
+    "test"
+  ],
+  "peerDependencies": {
+    "koishi": "^4.10.0",
+    "koishi-plugin-nonebot": "^1.2.2"
+  },
+  "devDependencies": {
+    "@types/node": "^18.16.14",
+    "atsc": "^1.2.2",
+    "koishi": "^4.13.0",
+    "koishi-plugin-nonebot": "^1.2.2",
+    "typescript": "^5.0.4"
+  }
+}

--- a/plugins/test/package.json
+++ b/plugins/test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "koishi-plugin-nonebotjs-tester",
+  "name": "koishi-plugin-nonebotjs-test",
   "description": "plugin test nonebotjs",
   "version": "1.0.0",
   "main": "lib/index.js",

--- a/plugins/test/src/index.ts
+++ b/plugins/test/src/index.ts
@@ -1,0 +1,15 @@
+import { Context, Schema } from 'koishi'
+import {} from 'koishi-plugin-nonebot'
+import { resolve } from 'path'
+
+export const name = 'nonebotjs-test'
+export const using = ['nonebot']
+
+export interface Config {}
+
+export const Config: Schema<Config> = Schema.object({})
+
+export async function apply(ctx: Context, config: Config) {
+  await ctx.nonebot.install(resolve(__dirname, '../dist'))
+  await ctx.nonebot.import(resolve(__dirname, '../test'), config)
+}

--- a/plugins/test/tsconfig.json
+++ b/plugins/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+  },
+  "include": [
+    "src",
+  ],
+}

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -6,4 +6,7 @@ export const namePil = 'PIL-9.1.1-cp310-cp310-emscripten_3_1_14_wasm32.whl'
 
 export const nameNumpy = 'numpy-1.22.4-cp310-cp310-emscripten_3_1_14_wasm32.whl'
 
+
+export const loguruSource = 'https://files.pythonhosted.org/packages/71/bd/337f7a0cd2628c4c77512d78e26f93b13c327a2ddf2132001dd78c000bf4/loguru-0.7.0-py3-none-any.whl#sha256=b93aa30099fa6860d4727f1b81f8718e965bb96253fa190fab2077aaad6d15d3'
+
 export const nameLoguru = 'loguru-0.7.0-py3-none-any.whl'

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -6,7 +6,8 @@ export const namePil = 'PIL-9.1.1-cp310-cp310-emscripten_3_1_14_wasm32.whl'
 
 export const nameNumpy = 'numpy-1.22.4-cp310-cp310-emscripten_3_1_14_wasm32.whl'
 
-
-export const loguruSource = 'https://files.pythonhosted.org/packages/71/bd/337f7a0cd2628c4c77512d78e26f93b13c327a2ddf2132001dd78c000bf4/loguru-0.7.0-py3-none-any.whl#sha256=b93aa30099fa6860d4727f1b81f8718e965bb96253fa190fab2077aaad6d15d3'
+export const loguruSource = 'https://files.pythonhosted.org/packages/71/bd/'
+  + '337f7a0cd2628c4c77512d78e26f93b13c327a2ddf2132001dd78c000bf4/loguru-0.7.0-py3-none-any.whl'
+ + '#sha256=b93aa30099fa6860d4727f1b81f8718e965bb96253fa190fab2077aaad6d15d3'
 
 export const nameLoguru = 'loguru-0.7.0-py3-none-any.whl'

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -5,3 +5,5 @@ export const namePyyaml = 'PyYAML-6.0-cp310-cp310-emscripten_3_1_14_wasm32.whl'
 export const namePil = 'PIL-9.1.1-cp310-cp310-emscripten_3_1_14_wasm32.whl'
 
 export const nameNumpy = 'numpy-1.22.4-cp310-cp310-emscripten_3_1_14_wasm32.whl'
+
+export const nameLoguru = 'loguru-0.7.0-py3-none-any.whl'

--- a/scripts/nbp.ts
+++ b/scripts/nbp.ts
@@ -47,14 +47,14 @@ function skip(name: string, blacklist: string[]) {
 
 const preparePyodide = async () => {
   const pathCache = resolve(__dirname, '../build/cache')
-  await mkdir(pathCache, {recursive: true})
+  await mkdir(pathCache, { recursive: true })
 
   const pathExtracted = join(pathCache, 'pyodide')
-  await mkdir(pathExtracted, {recursive: true})
+  await mkdir(pathExtracted, { recursive: true })
 
   if (!await exists(join(pathExtracted, 'pyodide.js'))) {
     const stream = await download(pyodideSource)
-    await promisify(finished)(stream.pipe(bz2()).pipe(extract({cwd: pathExtracted, strip: 1})))
+    await promisify(finished)(stream.pipe(bz2()).pipe(extract({ cwd: pathExtracted, strip: 1 })))
   }
 
   return pathExtracted
@@ -67,7 +67,7 @@ const buildNonebot = async () => {
   const pathDist = join(pathPackage, 'dist')
 
   if (await exists(pathDist)) return
-  await mkdir(pathDist, {recursive: true})
+  await mkdir(pathDist, { recursive: true })
 
   await Promise.all(
     [
@@ -106,10 +106,10 @@ const buildPlugin = async (path: string) => {
   const pathDist = join(pathPackage, 'dist')
 
   if (await exists(pathDist)) return
-  await mkdir(pathDist, {recursive: true})
+  await mkdir(pathDist, { recursive: true })
 
   // Parents of each cycle
-  const {name, version, exclude = []} = JSON.parse(await readFile(join(pathPackage, 'nbp.json'), 'utf-8'))
+  const { name, version, exclude = [] } = JSON.parse(await readFile(join(pathPackage, 'nbp.json'), 'utf-8'))
   let parents = [`${name}==${version}`]
   // Finally collected deps
   const deps: JohnnydepItem[] = []
@@ -180,7 +180,7 @@ const buildPlugin = async (path: string) => {
     if (!x.url.endsWith('.tar.gz')) {
       return promisify(finished)(stream.pipe(createWriteStream(join(pathDist, x.filename))))
     }
-    await mkdir(pathDist, {recursive: true})
+    await mkdir(pathDist, { recursive: true })
     await promisify(finished)(stream.pipe(extract({
       cwd: pathDist,
       newer: true,
@@ -196,7 +196,7 @@ const buildPlugin = async (path: string) => {
   await writeFile(
     join(pathDist, 'deps.json'),
     JSON.stringify(
-      resultDeps.map((x) => ({name: x.name, filename: x.filename}))
+      resultDeps.map((x) => ({ name: x.name, filename: x.filename }))
     )
   )
 }

--- a/scripts/nbp.ts
+++ b/scripts/nbp.ts
@@ -1,205 +1,211 @@
-import { createWriteStream } from 'node:fs'
-import { cp, mkdir, readFile, writeFile } from 'node:fs/promises'
-import { basename, join, resolve } from 'node:path'
-import { finished } from 'node:stream'
-import { promisify } from 'node:util'
-import { extract } from 'tar'
+import {createWriteStream} from 'node:fs'
+import {cp, mkdir, readFile, writeFile} from 'node:fs/promises'
+import {basename, join, resolve} from 'node:path'
+import {finished} from 'node:stream'
+import {promisify} from 'node:util'
+import {extract} from 'tar'
 import bz2 from 'unbzip2-stream'
-import { register } from 'yakumo'
-import { nameNumpy, namePil, pyodideSource } from './config'
-import { download, exists, spawnOutput } from './utils'
+import {register} from 'yakumo'
+import {nameLoguru, nameNumpy, namePil, pyodideSource} from './config'
+import {download, exists, spawnOutput} from './utils'
 
 const blacklist = [
-  'nonebot-adapter-onebot',
-  'nonebot-plugin-apscheduler',
-  'nonebot-plugin-htmlrender',
-  'nonebot2',
-  'httpx',
-  'aiohttp',
-  'pydantic',
-  'build',
-  'twine',
-  'pil',
-  'pillow',
-  'numpy',
-  'setuptools',
+    'nonebot-adapter-onebot',
+    'nonebot-plugin-apscheduler',
+    'nonebot-plugin-htmlrender',
+    'nonebot2',
+    'httpx',
+    'aiohttp',
+    'pydantic',
+    'build',
+    'twine',
+    'pil',
+    'pillow',
+    'numpy',
+    'loguru',
+    'setuptools',
 ]
 
 interface JohnnydepItem {
-  name: string
-  version_latest_in_spec: string
-  download_link: string
-  requires: string[]
+    name: string
+    version_latest_in_spec: string
+    download_link: string
+    requires: string[]
 }
 
 function skip(name: string, blacklist: string[]) {
-  name = name
-    .split('[')[0]
-    .split('<')[0]
-    .split('>')[0]
-    .split('=')[0]
-    .split('!')[0]
-    .toLowerCase()
-    .replace(/_/g, '-')
-  return !blacklist.some((y) => name === y.toLowerCase().replace(/_/g, '-'))
+    name = name
+        .split('[')[0]
+        .split('<')[0]
+        .split('>')[0]
+        .split('=')[0]
+        .split('!')[0]
+        .toLowerCase()
+        .replace(/_/g, '-')
+    return !blacklist.some((y) => name === y.toLowerCase().replace(/_/g, '-'))
 }
 
 const preparePyodide = async () => {
-  const pathCache = resolve(__dirname, '../build/cache')
-  await mkdir(pathCache, { recursive: true })
+    const pathCache = resolve(__dirname, '../build/cache')
+    await mkdir(pathCache, {recursive: true})
 
-  const pathExtracted = join(pathCache, 'pyodide')
-  await mkdir(pathExtracted, { recursive: true })
+    const pathExtracted = join(pathCache, 'pyodide')
+    await mkdir(pathExtracted, {recursive: true})
 
-  if (!await exists(join(pathExtracted, 'pyodide.js'))) {
-    const stream = await download(pyodideSource)
-    await promisify(finished)(stream.pipe(bz2()).pipe(extract({ cwd: pathExtracted, strip: 1 })))
-  }
+    if (!await exists(join(pathExtracted, 'pyodide.js'))) {
+        const stream = await download(pyodideSource)
+        await promisify(finished)(stream.pipe(bz2()).pipe(extract({cwd: pathExtracted, strip: 1})))
+    }
 
-  return pathExtracted
+    return pathExtracted
 }
 
 const buildNonebot = async () => {
-  const pathPyodide = await preparePyodide()
+    const pathPyodide = await preparePyodide()
 
-  const pathPackage = resolve(__dirname, '../packages/nonebot')
-  const pathDist = join(pathPackage, 'dist')
+    const pathPackage = resolve(__dirname, '../packages/nonebot')
+    const pathDist = join(pathPackage, 'dist')
 
-  if (await exists(pathDist)) return
-  await mkdir(pathDist, { recursive: true })
+    if (await exists(pathDist)) return
+    await mkdir(pathDist, {recursive: true})
 
-  await Promise.all(
-    [
-      // namePyyaml,
-      namePil,
-      nameNumpy,
-    ].map((x) => cp(join(pathPyodide, x), join(pathDist, x)))
-  )
+    await Promise.all(
+        [
+            // namePyyaml,
+            namePil,
+            nameNumpy,
+            nameLoguru
+        ].map((x) => cp(join(pathPyodide, x), join(pathDist, x)))
+    )
 
-  await writeFile(
-    join(pathDist, 'deps.json'),
-    JSON.stringify([
-      // {
-      //   name: 'yaml',
-      //   filename: namePyyaml,
-      // },
-      {
-        name: 'PIL',
-        filename: namePil,
-      },
-      {
-        name: 'numpy',
-        filename: nameNumpy,
-      },
-    ])
-  )
+    await writeFile(
+        join(pathDist, 'deps.json'),
+        JSON.stringify([
+            // {
+            //   name: 'yaml',
+            //   filename: namePyyaml,
+            // },
+            {
+                name: 'PIL',
+                filename: namePil,
+            },
+            {
+                name: 'numpy',
+                filename: nameNumpy,
+            },
+            {
+                name: 'loguru',
+                filename: nameLoguru,
+            },
+        ])
+    )
 }
 
 const buildPlugin = async (path: string) => {
-  const pathPackage = resolve(__dirname, `..${path}`)
-  const pathDist = join(pathPackage, 'dist')
+    const pathPackage = resolve(__dirname, `..${path}`)
+    const pathDist = join(pathPackage, 'dist')
 
-  if (await exists(pathDist)) return
-  await mkdir(pathDist, { recursive: true })
+    if (await exists(pathDist)) return
+    await mkdir(pathDist, {recursive: true})
 
-  // Parents of each cycle
-  const { name, version, exclude = [] } = JSON.parse(await readFile(join(pathPackage, 'nbp.json'), 'utf-8'))
-  let parents = [`${name}==${version}`]
-  // Finally collected deps
-  const deps: JohnnydepItem[] = []
+    // Parents of each cycle
+    const {name, version, exclude = []} = JSON.parse(await readFile(join(pathPackage, 'nbp.json'), 'utf-8'))
+    let parents = [`${name}==${version}`]
+    // Finally collected deps
+    const deps: JohnnydepItem[] = []
 
-  while (parents.length) {
-    // Collected results
-    const results: JohnnydepItem[][] = []
+    while (parents.length) {
+        // Collected results
+        const results: JohnnydepItem[][] = []
 
-    // Collect
-    for (const parent of parents) {
-      results.push(JSON.parse(await spawnOutput('python', [
-        '-m',
-        'johnnydep',
-        '-f',
-        'ALL',
-        '-o',
-        'json',
-        '--no-deps',
-        parent,
-      ])))
+        // Collect
+        for (const parent of parents) {
+            results.push(JSON.parse(await spawnOutput('python', [
+                '-m',
+                'johnnydep',
+                '-f',
+                'ALL',
+                '-o',
+                'json',
+                '--no-deps',
+                parent,
+            ])))
+        }
+
+        // Filter requirements of results info parents of next cycle
+        parents = results
+            .map((result) => result[0].requires.filter(x => skip(x, [...blacklist, ...exclude])))
+            .flat()
+
+        // Push deps
+        for (const result of results.flat()) {
+            const conflictedIndex = deps.findIndex((x) => x.name === result.name)
+            if (conflictedIndex === -1) {
+                deps.push(result)
+                continue
+            }
+
+            const confilcted = deps[conflictedIndex]
+            const versions_available: string[] = JSON.parse(
+                await spawnOutput('python', [
+                    '-m',
+                    'johnnydep',
+                    '-f',
+                    'versions_available',
+                    '-o',
+                    'json',
+                    '--no-deps',
+                    result.name,
+                ])
+            )[0].versions_available
+
+            const selected =
+                versions_available.indexOf(confilcted.version_latest_in_spec) >
+                versions_available.indexOf(result.version_latest_in_spec)
+                    ? confilcted
+                    : result
+            deps.splice(conflictedIndex, 1, selected)
+        }
     }
 
-    // Filter requirements of results info parents of next cycle
-    parents = results
-      .map((result) => result[0].requires.filter(x => skip(x, [...blacklist, ...exclude])))
-      .flat()
+    const resultDeps = deps.slice(1).map((x) => ({
+        name: x.name,
+        version: x.version_latest_in_spec,
+        filename: x.download_link.endsWith('.tar.gz') ? x.name : basename(x.download_link),
+        url: x.download_link,
+    }))
 
-    // Push deps
-    for (const result of results.flat()) {
-      const conflictedIndex = deps.findIndex((x) => x.name === result.name)
-      if (conflictedIndex === -1) {
-        deps.push(result)
-        continue
-      }
+    await Promise.all(resultDeps.map(async (x) => {
+        const stream = await download(x.url)
+        if (!x.url.endsWith('.tar.gz')) {
+            return promisify(finished)(stream.pipe(createWriteStream(join(pathDist, x.filename))))
+        }
+        await mkdir(pathDist, {recursive: true})
+        await promisify(finished)(stream.pipe(extract({
+            cwd: pathDist,
+            newer: true,
+            strip: 1,
+            filter(path, stat) {
+                if (!path.endsWith('/')) return true
+                const segments = path.split(/\//g)
+                return segments[1] === x.name
+            },
+        })))
+    }))
 
-      const confilcted = deps[conflictedIndex]
-      const versions_available: string[] = JSON.parse(
-        await spawnOutput('python', [
-          '-m',
-          'johnnydep',
-          '-f',
-          'versions_available',
-          '-o',
-          'json',
-          '--no-deps',
-          result.name,
-        ])
-      )[0].versions_available
-
-      const selected =
-        versions_available.indexOf(confilcted.version_latest_in_spec) >
-        versions_available.indexOf(result.version_latest_in_spec)
-          ? confilcted
-          : result
-      deps.splice(conflictedIndex, 1, selected)
-    }
-  }
-
-  const resultDeps = deps.slice(1).map((x) => ({
-    name: x.name,
-    version: x.version_latest_in_spec,
-    filename: x.download_link.endsWith('.tar.gz') ? x.name : basename(x.download_link),
-    url: x.download_link,
-  }))
-
-  await Promise.all(resultDeps.map(async (x) => {
-    const stream = await download(x.url)
-    if (!x.url.endsWith('.tar.gz')) {
-      return promisify(finished)(stream.pipe(createWriteStream(join(pathDist, x.filename))))
-    }
-    await mkdir(pathDist, { recursive: true })
-    await promisify(finished)(stream.pipe(extract({
-      cwd: pathDist,
-      newer: true,
-      strip: 1,
-      filter(path, stat) {
-        if (!path.endsWith('/')) return true
-        const segments = path.split(/\//g)
-        return segments[1] === x.name
-      },
-    })))
-  }))
-
-  await writeFile(
-    join(pathDist, 'deps.json'),
-    JSON.stringify(
-      resultDeps.map((x) => ({ name: x.name, filename: x.filename }))
+    await writeFile(
+        join(pathDist, 'deps.json'),
+        JSON.stringify(
+            resultDeps.map((x) => ({name: x.name, filename: x.filename}))
+        )
     )
-  )
 }
 
 register('nbp', (project) => {
-  const tasks = Object
-    .keys(project.targets)
-    .filter(path => path.startsWith('/plugins') && !path.includes('_template'))
-    .map(buildPlugin)
-  tasks.push(buildNonebot())
-  return Promise.all(tasks)
+    const tasks = Object
+        .keys(project.targets)
+        .filter(path => path.startsWith('/plugins') && !path.includes('_template'))
+        .map(buildPlugin)
+    tasks.push(buildNonebot())
+    return Promise.all(tasks)
 })

--- a/scripts/nbp.ts
+++ b/scripts/nbp.ts
@@ -79,8 +79,8 @@ const buildNonebot = async () => {
       // namePyyaml,
       namePil,
       nameNumpy,
-      nameLoguru
-    ].map((x) => cp(join(pathPyodide, x), join(pathDist, x)))
+      nameLoguru,
+    ].map((x) => cp(join(pathPyodide, x), join(pathDist, x))),
   )
 
   await writeFile(
@@ -102,7 +102,7 @@ const buildNonebot = async () => {
         name: 'loguru',
         filename: nameLoguru,
       },
-    ])
+    ]),
   )
 }
 
@@ -150,7 +150,7 @@ const buildPlugin = async (path: string) => {
         continue
       }
 
-      const confilcted = deps[conflictedIndex]
+      const conflicted = deps[conflictedIndex]
       const versions_available: string[] = JSON.parse(
         await spawnOutput('python', [
           '-m',
@@ -161,13 +161,13 @@ const buildPlugin = async (path: string) => {
           'json',
           '--no-deps',
           result.name,
-        ])
+        ]),
       )[0].versions_available
 
-      const selected =
-        versions_available.indexOf(confilcted.version_latest_in_spec) >
-        versions_available.indexOf(result.version_latest_in_spec)
-          ? confilcted
+      const selected
+        = versions_available.indexOf(conflicted.version_latest_in_spec)
+        > versions_available.indexOf(result.version_latest_in_spec)
+          ? conflicted
           : result
       deps.splice(conflictedIndex, 1, selected)
     }
@@ -201,8 +201,8 @@ const buildPlugin = async (path: string) => {
   await writeFile(
     join(pathDist, 'deps.json'),
     JSON.stringify(
-      resultDeps.map((x) => ({ name: x.name, filename: x.filename }))
-    )
+      resultDeps.map((x) => ({ name: x.name, filename: x.filename })),
+    ),
   )
 }
 

--- a/scripts/nbp.ts
+++ b/scripts/nbp.ts
@@ -1,211 +1,211 @@
-import {createWriteStream} from 'node:fs'
-import {cp, mkdir, readFile, writeFile} from 'node:fs/promises'
-import {basename, join, resolve} from 'node:path'
-import {finished} from 'node:stream'
-import {promisify} from 'node:util'
-import {extract} from 'tar'
+import { createWriteStream } from 'node:fs'
+import { cp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { finished } from 'node:stream'
+import { promisify } from 'node:util'
+import { extract } from 'tar'
 import bz2 from 'unbzip2-stream'
-import {register} from 'yakumo'
-import {nameLoguru, nameNumpy, namePil, pyodideSource} from './config'
-import {download, exists, spawnOutput} from './utils'
+import { register } from 'yakumo'
+import { nameLoguru, nameNumpy, namePil, pyodideSource } from './config'
+import { download, exists, spawnOutput } from './utils'
 
 const blacklist = [
-    'nonebot-adapter-onebot',
-    'nonebot-plugin-apscheduler',
-    'nonebot-plugin-htmlrender',
-    'nonebot2',
-    'httpx',
-    'aiohttp',
-    'pydantic',
-    'build',
-    'twine',
-    'pil',
-    'pillow',
-    'numpy',
-    'loguru',
-    'setuptools',
+  'nonebot-adapter-onebot',
+  'nonebot-plugin-apscheduler',
+  'nonebot-plugin-htmlrender',
+  'nonebot2',
+  'httpx',
+  'aiohttp',
+  'pydantic',
+  'build',
+  'twine',
+  'pil',
+  'pillow',
+  'numpy',
+  'loguru',
+  'setuptools',
 ]
 
 interface JohnnydepItem {
-    name: string
-    version_latest_in_spec: string
-    download_link: string
-    requires: string[]
+  name: string
+  version_latest_in_spec: string
+  download_link: string
+  requires: string[]
 }
 
 function skip(name: string, blacklist: string[]) {
-    name = name
-        .split('[')[0]
-        .split('<')[0]
-        .split('>')[0]
-        .split('=')[0]
-        .split('!')[0]
-        .toLowerCase()
-        .replace(/_/g, '-')
-    return !blacklist.some((y) => name === y.toLowerCase().replace(/_/g, '-'))
+  name = name
+    .split('[')[0]
+    .split('<')[0]
+    .split('>')[0]
+    .split('=')[0]
+    .split('!')[0]
+    .toLowerCase()
+    .replace(/_/g, '-')
+  return !blacklist.some((y) => name === y.toLowerCase().replace(/_/g, '-'))
 }
 
 const preparePyodide = async () => {
-    const pathCache = resolve(__dirname, '../build/cache')
-    await mkdir(pathCache, {recursive: true})
+  const pathCache = resolve(__dirname, '../build/cache')
+  await mkdir(pathCache, {recursive: true})
 
-    const pathExtracted = join(pathCache, 'pyodide')
-    await mkdir(pathExtracted, {recursive: true})
+  const pathExtracted = join(pathCache, 'pyodide')
+  await mkdir(pathExtracted, {recursive: true})
 
-    if (!await exists(join(pathExtracted, 'pyodide.js'))) {
-        const stream = await download(pyodideSource)
-        await promisify(finished)(stream.pipe(bz2()).pipe(extract({cwd: pathExtracted, strip: 1})))
-    }
+  if (!await exists(join(pathExtracted, 'pyodide.js'))) {
+    const stream = await download(pyodideSource)
+    await promisify(finished)(stream.pipe(bz2()).pipe(extract({cwd: pathExtracted, strip: 1})))
+  }
 
-    return pathExtracted
+  return pathExtracted
 }
 
 const buildNonebot = async () => {
-    const pathPyodide = await preparePyodide()
+  const pathPyodide = await preparePyodide()
 
-    const pathPackage = resolve(__dirname, '../packages/nonebot')
-    const pathDist = join(pathPackage, 'dist')
+  const pathPackage = resolve(__dirname, '../packages/nonebot')
+  const pathDist = join(pathPackage, 'dist')
 
-    if (await exists(pathDist)) return
-    await mkdir(pathDist, {recursive: true})
+  if (await exists(pathDist)) return
+  await mkdir(pathDist, {recursive: true})
 
-    await Promise.all(
-        [
-            // namePyyaml,
-            namePil,
-            nameNumpy,
-            nameLoguru
-        ].map((x) => cp(join(pathPyodide, x), join(pathDist, x)))
-    )
+  await Promise.all(
+    [
+      // namePyyaml,
+      namePil,
+      nameNumpy,
+      nameLoguru
+    ].map((x) => cp(join(pathPyodide, x), join(pathDist, x)))
+  )
 
-    await writeFile(
-        join(pathDist, 'deps.json'),
-        JSON.stringify([
-            // {
-            //   name: 'yaml',
-            //   filename: namePyyaml,
-            // },
-            {
-                name: 'PIL',
-                filename: namePil,
-            },
-            {
-                name: 'numpy',
-                filename: nameNumpy,
-            },
-            {
-                name: 'loguru',
-                filename: nameLoguru,
-            },
-        ])
-    )
+  await writeFile(
+    join(pathDist, 'deps.json'),
+    JSON.stringify([
+      // {
+      //   name: 'yaml',
+      //   filename: namePyyaml,
+      // },
+      {
+        name: 'PIL',
+        filename: namePil,
+      },
+      {
+        name: 'numpy',
+        filename: nameNumpy,
+      },
+      {
+        name: 'loguru',
+        filename: nameLoguru,
+      },
+    ])
+  )
 }
 
 const buildPlugin = async (path: string) => {
-    const pathPackage = resolve(__dirname, `..${path}`)
-    const pathDist = join(pathPackage, 'dist')
+  const pathPackage = resolve(__dirname, `..${path}`)
+  const pathDist = join(pathPackage, 'dist')
 
-    if (await exists(pathDist)) return
-    await mkdir(pathDist, {recursive: true})
+  if (await exists(pathDist)) return
+  await mkdir(pathDist, {recursive: true})
 
-    // Parents of each cycle
-    const {name, version, exclude = []} = JSON.parse(await readFile(join(pathPackage, 'nbp.json'), 'utf-8'))
-    let parents = [`${name}==${version}`]
-    // Finally collected deps
-    const deps: JohnnydepItem[] = []
+  // Parents of each cycle
+  const {name, version, exclude = []} = JSON.parse(await readFile(join(pathPackage, 'nbp.json'), 'utf-8'))
+  let parents = [`${name}==${version}`]
+  // Finally collected deps
+  const deps: JohnnydepItem[] = []
 
-    while (parents.length) {
-        // Collected results
-        const results: JohnnydepItem[][] = []
+  while (parents.length) {
+    // Collected results
+    const results: JohnnydepItem[][] = []
 
-        // Collect
-        for (const parent of parents) {
-            results.push(JSON.parse(await spawnOutput('python', [
-                '-m',
-                'johnnydep',
-                '-f',
-                'ALL',
-                '-o',
-                'json',
-                '--no-deps',
-                parent,
-            ])))
-        }
-
-        // Filter requirements of results info parents of next cycle
-        parents = results
-            .map((result) => result[0].requires.filter(x => skip(x, [...blacklist, ...exclude])))
-            .flat()
-
-        // Push deps
-        for (const result of results.flat()) {
-            const conflictedIndex = deps.findIndex((x) => x.name === result.name)
-            if (conflictedIndex === -1) {
-                deps.push(result)
-                continue
-            }
-
-            const confilcted = deps[conflictedIndex]
-            const versions_available: string[] = JSON.parse(
-                await spawnOutput('python', [
-                    '-m',
-                    'johnnydep',
-                    '-f',
-                    'versions_available',
-                    '-o',
-                    'json',
-                    '--no-deps',
-                    result.name,
-                ])
-            )[0].versions_available
-
-            const selected =
-                versions_available.indexOf(confilcted.version_latest_in_spec) >
-                versions_available.indexOf(result.version_latest_in_spec)
-                    ? confilcted
-                    : result
-            deps.splice(conflictedIndex, 1, selected)
-        }
+    // Collect
+    for (const parent of parents) {
+      results.push(JSON.parse(await spawnOutput('python', [
+        '-m',
+        'johnnydep',
+        '-f',
+        'ALL',
+        '-o',
+        'json',
+        '--no-deps',
+        parent,
+      ])))
     }
 
-    const resultDeps = deps.slice(1).map((x) => ({
-        name: x.name,
-        version: x.version_latest_in_spec,
-        filename: x.download_link.endsWith('.tar.gz') ? x.name : basename(x.download_link),
-        url: x.download_link,
-    }))
+    // Filter requirements of results info parents of next cycle
+    parents = results
+      .map((result) => result[0].requires.filter(x => skip(x, [...blacklist, ...exclude])))
+      .flat()
 
-    await Promise.all(resultDeps.map(async (x) => {
-        const stream = await download(x.url)
-        if (!x.url.endsWith('.tar.gz')) {
-            return promisify(finished)(stream.pipe(createWriteStream(join(pathDist, x.filename))))
-        }
-        await mkdir(pathDist, {recursive: true})
-        await promisify(finished)(stream.pipe(extract({
-            cwd: pathDist,
-            newer: true,
-            strip: 1,
-            filter(path, stat) {
-                if (!path.endsWith('/')) return true
-                const segments = path.split(/\//g)
-                return segments[1] === x.name
-            },
-        })))
-    }))
+    // Push deps
+    for (const result of results.flat()) {
+      const conflictedIndex = deps.findIndex((x) => x.name === result.name)
+      if (conflictedIndex === -1) {
+        deps.push(result)
+        continue
+      }
 
-    await writeFile(
-        join(pathDist, 'deps.json'),
-        JSON.stringify(
-            resultDeps.map((x) => ({name: x.name, filename: x.filename}))
-        )
+      const confilcted = deps[conflictedIndex]
+      const versions_available: string[] = JSON.parse(
+        await spawnOutput('python', [
+          '-m',
+          'johnnydep',
+          '-f',
+          'versions_available',
+          '-o',
+          'json',
+          '--no-deps',
+          result.name,
+        ])
+      )[0].versions_available
+
+      const selected =
+        versions_available.indexOf(confilcted.version_latest_in_spec) >
+        versions_available.indexOf(result.version_latest_in_spec)
+          ? confilcted
+          : result
+      deps.splice(conflictedIndex, 1, selected)
+    }
+  }
+
+  const resultDeps = deps.slice(1).map((x) => ({
+    name: x.name,
+    version: x.version_latest_in_spec,
+    filename: x.download_link.endsWith('.tar.gz') ? x.name : basename(x.download_link),
+    url: x.download_link,
+  }))
+
+  await Promise.all(resultDeps.map(async (x) => {
+    const stream = await download(x.url)
+    if (!x.url.endsWith('.tar.gz')) {
+      return promisify(finished)(stream.pipe(createWriteStream(join(pathDist, x.filename))))
+    }
+    await mkdir(pathDist, {recursive: true})
+    await promisify(finished)(stream.pipe(extract({
+      cwd: pathDist,
+      newer: true,
+      strip: 1,
+      filter(path, stat) {
+        if (!path.endsWith('/')) return true
+        const segments = path.split(/\//g)
+        return segments[1] === x.name
+      },
+    })))
+  }))
+
+  await writeFile(
+    join(pathDist, 'deps.json'),
+    JSON.stringify(
+      resultDeps.map((x) => ({name: x.name, filename: x.filename}))
     )
+  )
 }
 
 register('nbp', (project) => {
-    const tasks = Object
-        .keys(project.targets)
-        .filter(path => path.startsWith('/plugins') && !path.includes('_template'))
-        .map(buildPlugin)
-    tasks.push(buildNonebot())
-    return Promise.all(tasks)
+  const tasks = Object
+    .keys(project.targets)
+    .filter(path => path.startsWith('/plugins') && !path.includes('_template'))
+    .map(buildPlugin)
+  tasks.push(buildNonebot())
+  return Promise.all(tasks)
 })

--- a/scripts/nbp.ts
+++ b/scripts/nbp.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util'
 import { extract } from 'tar'
 import bz2 from 'unbzip2-stream'
 import { register } from 'yakumo'
-import { nameLoguru, nameNumpy, namePil, pyodideSource } from './config'
+import { loguruSource, nameLoguru, nameNumpy, namePil, pyodideSource } from './config'
 import { download, exists, spawnOutput } from './utils'
 
 const blacklist = [
@@ -55,6 +55,11 @@ const preparePyodide = async () => {
   if (!await exists(join(pathExtracted, 'pyodide.js'))) {
     const stream = await download(pyodideSource)
     await promisify(finished)(stream.pipe(bz2()).pipe(extract({ cwd: pathExtracted, strip: 1 })))
+  }
+
+  if (!await exists(join(pathExtracted, nameLoguru))) {
+    const stream = await download(loguruSource)
+    await promisify(finished)(stream.pipe(createWriteStream(join(pathExtracted, nameLoguru))))
   }
 
   return pathExtracted
@@ -185,7 +190,7 @@ const buildPlugin = async (path: string) => {
       cwd: pathDist,
       newer: true,
       strip: 1,
-      filter(path, stat) {
+      filter(path) {
         if (!path.endsWith('/')) return true
         const segments = path.split(/\//g)
         return segments[1] === x.name

--- a/scripts/pack.ts
+++ b/scripts/pack.ts
@@ -12,8 +12,8 @@ register('nbp-pack', async (project) => {
     Object.keys(project.targets)
       .filter(
         (path) =>
-          (path.startsWith('/plugins') && !path.includes('_template')) ||
-          path === '/packages/nonebot'
+          (path.startsWith('/plugins') && !path.includes('_template'))
+          || path === '/packages/nonebot',
       )
       .map((path) => project.targets[path])
       .map((pkgJson) =>
@@ -27,9 +27,9 @@ register('nbp-pack', async (project) => {
             pathDist,
             `${pkgJson.name
               .replace('@nonebot/', '')
-              .replace('koishi-plugin-', '')}-${pkgJson.version}.tgz`
+              .replace('koishi-plugin-', '')}-${pkgJson.version}.tgz`,
           ),
-        ])
-      )
+        ]),
+      ),
   )
 })

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -21,7 +21,7 @@ function copyFiles(path: string) {
       writeFileSync(dest, content
         .replace(/nonebot_plugin_template/g, fullname)
         .replace(/template/g, name)
-        .replace(/  "private": true,\r?\n/g, ''))
+        .replace(/ {2}"private": true,\r?\n/g, ''))
     }
   }
 }
@@ -32,5 +32,5 @@ async function main() {
 }
 
 if (module === require.main) {
-  main()
+  main().then()
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,6 +952,11 @@
   resolved "https://registry.npmmirror.com/@types/node/-/node-18.16.14.tgz#ab67bb907f1146afc6fedb9ce60ae8a99c989631"
   integrity sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==
 
+"@types/node@^20.2.5":
+  version "20.3.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.1.tgz#e8a83f1aa8b649377bb1fb5d7bac5cb90e784dfe"
+  integrity sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==
+
 "@types/qs@*", "@types/qs@^6.5.3":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"


### PR DESCRIPTION
### 待实现
- [x] 选择合适的 reggol level，而不是暂时全部 info

### 示例
1. 基础使用
    <img width="348" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/9bbaaf6e-a519-4e7c-a9da-652c391d7e0b">
    <img width="621" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/90f76343-050d-464b-bbb0-3e482cc773fd">

2. 格式化日志输出
    <img width="545" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/2c9e9ccb-35d6-408b-950d-803bedb21f1d">
    <img width="618" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/f8f65317-daf0-4ea2-999b-c2962a785c39">
3. 彩色日志输出
    <img width="661" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/5f8ced68-5e6f-4c3d-aa64-2e7526b216d2">
    <img width="614" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/e6bb9eae-5fdb-40c5-a2b4-565819217605">
4. 捕获错误
    <img width="537" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/0a22ba61-26bc-4861-99b4-0d0ebc9cedb8">
    <img width="1183" alt="image" src="https://github.com/nonebotjs/koishi-plugin-nonebot/assets/68551684/5c75147e-9896-43f2-86bd-b7693d5863f2">



